### PR TITLE
Mover lógica do AuthContext para Clean Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,16 @@ Utilizamos os princípios de Clean Architecture para organizar o projeto, separa
 ├── context
 ├── domain (camada de domínio)
 │   ├── repositories
+│   │   ├── AuthRepository.ts
 │   │   ├── BalanceRepository.ts
 │   │   └── TransactionsRepository.ts
 │   └── usecases
+│   │   ├── AuthUseCases.ts
 │   │   ├── BalanceUseCases.ts
 │   │   └── TransactionsUseCases.ts
 ├── infrastructure (camada de infraestrutura)
 │   ├── api
+│   │   ├── AuthApi.ts
 │   │   ├── BalanceApi.ts
 │   │   └── TransactionApi.ts
 │   └── firebase

--- a/app/screens/(auth)/login/index.tsx
+++ b/app/screens/(auth)/login/index.tsx
@@ -15,11 +15,12 @@ export default function Index() {
   const [showPassword, setShowPassword] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
 
-  async function makeLogin(email: string, password: string) {
+  async function loginUser(email: string, password: string) {
     setLoading(true);
     await handleLogin(email, password);
     setLoading(false);
   }
+
   return (
     <View style={styles.loginContainer}>
       <View style={styles.headerContainer}>
@@ -50,7 +51,7 @@ export default function Index() {
           title={loading ? "Entrando..." : "Entrar"}
           variant="primary"
           disabled={loading}
-          onPress={() => makeLogin(email, password)}
+          onPress={() => loginUser(email, password)}
         />
 
         <View style={styles.registerTextContainer}>

--- a/domain/repositories/AuthRepository.ts
+++ b/domain/repositories/AuthRepository.ts
@@ -1,0 +1,14 @@
+import { UserCredential } from "firebase/auth";
+
+export interface AuthRepository {
+  signInUser(
+    email: string,
+    password: string
+  ): Promise<{ userCredential: UserCredential }>;
+  signUpUser(
+    email: string,
+    password: string,
+    userName: string
+  ): Promise<{ success: boolean }>;
+  logoutUser(): Promise<{ success: boolean }>;
+}

--- a/domain/usecases/AuthUseCases.ts
+++ b/domain/usecases/AuthUseCases.ts
@@ -1,0 +1,17 @@
+import { authApi } from "@/infrastructure/api/AuthApi";
+
+export const signInUser = async (email: string, password: string) => {
+  return await authApi.signInUser(email, password);
+};
+
+export const signUpUser = async (
+  email: string,
+  password: string,
+  userName: string
+) => {
+  return await authApi.signUpUser(email, password, userName);
+};
+
+export const logoutUser = async () => {
+  return await authApi.logoutUser();
+};

--- a/infrastructure/api/AuthApi.ts
+++ b/infrastructure/api/AuthApi.ts
@@ -1,0 +1,53 @@
+import { AuthRepository } from "@/domain/repositories/AuthRepository";
+import { auth } from "@/infrastructure/firebase/config";
+import {
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  updateProfile,
+} from "firebase/auth";
+
+export const authApi: AuthRepository = {
+  signInUser: async (email: string, password: string) => {
+    try {
+      const userCredential = await signInWithEmailAndPassword(
+        auth,
+        email,
+        password
+      );
+
+      return { userCredential };
+    } catch {
+      throw new Error();
+    }
+  },
+
+  signUpUser: async (email, password, userName) => {
+    try {
+      await createUserWithEmailAndPassword(auth, email, password).then(() => {
+        if (auth?.currentUser) {
+          updateProfile(auth.currentUser, {
+            displayName: userName,
+          }).catch((error) => {
+            console.log("AuthProvider :: signUp - falha", error);
+            throw new Error();
+          });
+        }
+      });
+
+      return { success: true };
+    } catch (error) {
+      console.log("AuthProvider :: signUp - falha", error);
+      throw new Error();
+    }
+  },
+
+  logoutUser: async () => {
+    try {
+      await auth.signOut();
+      return { success: true };
+    } catch (error) {
+      console.log("AuthProvider :: signUp - falha", error);
+      throw new Error();
+    }
+  },
+};


### PR DESCRIPTION
Mantive a lógica dos toasts dentro da camada de apresentação (UI) porque no meu ponto de vista isso é de responsabilidade da UI e não do domínio de regra de negócio (usecases).